### PR TITLE
Refactor: Update localization and branding elements

### DIFF
--- a/frontend/src/components/DefaultChat/index.jsx
+++ b/frontend/src/components/DefaultChat/index.jsx
@@ -67,15 +67,7 @@ export default function DefaultChatContainer() {
           <UserIcon user={{ uid: "system" }} role={"assistant"} />
           <div>
             <MessageText>{t("welcomeMessage.part3")}</MessageText>
-            <a
-              href={paths.github()}
-              target="_blank"
-              rel="noreferrer"
-              className="mt-5 w-fit transition-all duration-300 border border-slate-200 px-4 py-2 rounded-lg text-white light:border-black/50 light:text-theme-text-primary text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
-            >
-              <GitMerge className="h-4 w-4" />
-              <p>{t("welcomeMessage.githubIssue")}</p>
-            </a>
+            {/* Link removed for de-open-sourcing */}
           </div>
         </MessageContent>
       </MessageContainer>
@@ -154,15 +146,7 @@ export default function DefaultChatContainer() {
             <MessageText>{t("welcomeMessage.part6")}</MessageText>
 
             <div className="flex flex-col md:flex-row items-start md:items-center gap-1 md:gap-4">
-              <a
-                href={paths.github()}
-                target="_blank"
-                rel="noreferrer"
-                className="mt-5 w-fit transition-all duration-300 border border-slate-200 px-4 py-2 rounded-lg text-white light:border-black/50 light:text-theme-text-primary text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"
-              >
-                <GithubLogo className="h-4 w-4" />
-                <p>{t("welcomeMessage.starOnGitHub")}</p>
-              </a>
+              {/* Link removed for de-open-sourcing */}
               <a
                 href={paths.mailToMintplex()}
                 className="mt-5 w-fit transition-all duration-300 border border-slate-200 px-4 py-2 rounded-lg text-white light:border-black/50 light:text-theme-text-primary text-sm items-center flex gap-x-2 hover:bg-slate-200 hover:text-slate-800 focus:ring-gray-800"

--- a/frontend/src/components/Footer/index.jsx
+++ b/frontend/src/components/Footer/index.jsx
@@ -51,23 +51,6 @@ export default function Footer() {
         <div className="flex space-x-4">
           <div className="flex w-fit">
             <Link
-              to={paths.github()}
-              target="_blank"
-              rel="noreferrer"
-              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
-              aria-label="Find us on GitHub"
-              data-tooltip-id="footer-item"
-              data-tooltip-content="View source code on GitHub"
-            >
-              <GithubLogo
-                weight="fill"
-                className="h-5 w-5"
-                color="var(--theme-sidebar-footer-icon-fill)"
-              />
-            </Link>
-          </div>
-          <div className="flex w-fit">
-            <Link
               to={paths.docs()}
               target="_blank"
               rel="noreferrer"
@@ -77,23 +60,6 @@ export default function Footer() {
               data-tooltip-content="Open AnythingLLM help docs"
             >
               <BookOpen
-                weight="fill"
-                className="h-5 w-5"
-                color="var(--theme-sidebar-footer-icon-fill)"
-              />
-            </Link>
-          </div>
-          <div className="flex w-fit">
-            <Link
-              to={paths.discord()}
-              target="_blank"
-              rel="noreferrer"
-              className="transition-all duration-300 p-2 rounded-full bg-theme-sidebar-footer-icon hover:bg-theme-sidebar-footer-icon-hover"
-              aria-label="Join our Discord server"
-              data-tooltip-id="footer-item"
-              data-tooltip-content="Join the AnythingLLM Discord"
-            >
-              <DiscordLogo
                 weight="fill"
                 className="h-5 w-5"
                 color="var(--theme-sidebar-footer-icon-fill)"

--- a/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
+++ b/frontend/src/components/LLMSelection/AwsBedrockLLMOptions/index.jsx
@@ -18,7 +18,7 @@ export default function AwsBedrockLLMOptions({ settings }) {
               You should use a properly defined IAM user for inferencing.
               <br />
               <a
-                href="https://docs.anythingllm.com/setup/llm-configuration/cloud/aws-bedrock"
+                href="https://nytte.ai/setup/llm-configuration/cloud/aws-bedrock"
                 target="_blank"
                 className="underline flex gap-x-1 items-center"
               >

--- a/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Github/index.jsx
+++ b/frontend/src/components/Modals/ManageWorkspace/DataConnectors/Connectors/Github/index.jsx
@@ -80,7 +80,7 @@ export default function GithubOptions() {
                   type="url"
                   name="repo"
                   className="border-none bg-theme-settings-input-bg text-white placeholder:text-theme-settings-input-placeholder text-sm rounded-lg focus:outline-primary-button active:outline-primary-button outline-none block w-full p-2.5"
-                  placeholder="https://github.com/Mintplex-Labs/anything-llm"
+                  placeholder="https://example.com/user/repository"
                   required={true}
                   autoComplete="off"
                   onChange={(e) => setRepo(e.target.value)}

--- a/frontend/src/components/SettingsSidebar/index.jsx
+++ b/frontend/src/components/SettingsSidebar/index.jsx
@@ -94,12 +94,7 @@ export default function SettingsSidebar() {
                   />
                 </div>
                 <div className="flex gap-x-2 items-center text-slate-500 shrink-0">
-                  <a
-                    href={paths.home()}
-                    className="transition-all duration-300 p-2 rounded-full text-white bg-theme-action-menu-bg hover:bg-theme-action-menu-item-hover hover:border-slate-100 hover:border-opacity-50 border-transparent border"
-                  >
-                    <House className="h-4 w-4" />
-                  </a>
+                  {/* Removed GitHub link per de-open-sourcing requirements */}
                 </div>
               </div>
 

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -8,7 +8,7 @@ i18next
   .use(initReactI18next) // Initialize i18n for React
   .use(LanguageDetector)
   .init({
-    fallbackLng: "en",
+    fallbackLng: "da", // Changed from "en" to "da"
     debug: import.meta.env.DEV,
     defaultNS,
     resources,

--- a/frontend/src/locales/da/common.js
+++ b/frontend/src/locales/da/common.js
@@ -127,8 +127,7 @@ const TRANSLATIONS = {
     },
   },
   welcomeMessage: {
-    part1:
-      "Velkommen til AnythingLLM, AnythingLLM er et open source AI-værktøj fra Mintplex Labs, der forvandler alt til en trænet chatbot, som du kan spørge og chatte med. AnythingLLM er en BYOK (bring-your-own-keys) software, så der er ingen abonnement, gebyr eller omkostninger forbundet med denne software udover de tjenester, du ønsker at bruge den med.",
+    part1: "",
     part2:
       "AnythingLLM er den nemmeste måde at samle kraftfulde AI-produkter som OpenAi, GPT-4, LangChain, PineconeDB, ChromaDB og andre tjenester i en praktisk pakke uden besvær, så du kan øge din produktivitet 100 gange.",
     part3:
@@ -144,7 +143,7 @@ const TRANSLATIONS = {
       "AnythingLLM er mere end en smartere Dropbox.\n\nAnythingLLM tilbyder to måder at kommunikere med dine data på:\n\n<i>Forespørgsel:</i> Dine chats vil returnere data eller inferenser fundet i de dokumenter, som dit arbejdsområde har adgang til. Tilføjelse af flere dokumenter til arbejdsområdet gør det klogere! \n\n<i>Samtalende:</i> Dine dokumenter + din løbende chat-historik bidrager begge til LLM'ens viden samtidigt. Perfekt til at tilføje realtids tekstbaserede oplysninger eller rette fejl og misforståelser, som LLM'en måtte have. \n\nDu kan skifte mellem de to tilstande \n<i>midt i en samtale!</i>",
     user3: "Wow, det lyder fantastisk, lad mig prøve det med det samme!",
     part6: "Hav det sjovt!",
-    starOnGitHub: "Giv en stjerne på GitHub",
+    starOnGitHub: "",
     contact: "Kontakt Mintplex Labs",
   },
   "new-workspace": {

--- a/frontend/src/locales/en/common.js
+++ b/frontend/src/locales/en/common.js
@@ -133,12 +133,12 @@ const TRANSLATIONS = {
 
   welcomeMessage: {
     part1:
-      "Welcome to AnythingLLM, AnythingLLM is an open-source AI tool by Mintplex Labs that turns anything into a trained chatbot you can query and chat with. AnythingLLM is a BYOK (bring-your-own-keys) software so there is no subscription, fee, or charges for this software outside of the services you want to use with it.",
+      "Welcome to AnythingLLM, an AI tool by Mintplex Labs that turns anything into a trained chatbot you can query and chat with. AnythingLLM is a BYOK (bring-your-own-keys) software so there is no subscription, fee, or charges for this software outside of the services you want to use with it.",
     part2:
       "AnythingLLM is the easiest way to put powerful AI products like OpenAi, GPT-4, LangChain, PineconeDB, ChromaDB, and other services together in a neat package with no fuss to increase your productivity by 100x.",
     part3:
       "AnythingLLM can run totally locally on your machine with little overhead you wont even notice it's there! No GPU needed. Cloud and on-premises installation is available as well.\nThe AI tooling ecosystem gets more powerful everyday. AnythingLLM makes it easy to use.",
-    githubIssue: "Create an issue on GitHub",
+    githubIssue: "",
     user1: "How do I get started?!",
     part4:
       "It's simple. All collections are organized into buckets we call \"Workspaces\". Workspaces are buckets of files, documents, images, PDFs, and other files which will be transformed into something LLM's can understand and use in conversation.\n\nYou can add and remove files at anytime.",
@@ -149,7 +149,7 @@ const TRANSLATIONS = {
       "AnythingLLM is more than a smarter Dropbox.\n\nAnythingLLM offers two ways of talking with your data:\n\n<i>Query:</i> Your chats will return data or inferences found with the documents in your workspace it has access to. Adding more documents to the Workspace make it smarter! \n\n<i>Conversational:</i> Your documents + your on-going chat history both contribute to the LLM knowledge at the same time. Great for appending real-time text-based info or corrections and misunderstandings the LLM might have. \n\nYou can toggle between either mode \n<i>in the middle of chatting!</i>",
     user3: "Wow, this sounds amazing, let me try it out already!",
     part6: "Have Fun!",
-    starOnGitHub: "Star on GitHub",
+    starOnGitHub: "",
     contact: "Contact Mintplex Labs",
   },
 
@@ -231,7 +231,7 @@ const TRANSLATIONS = {
       title: "Resources",
       links: {
         docs: "Docs",
-        star: "Star on Github",
+        star: "",
       },
     },
   },

--- a/frontend/src/locales/it/common.js
+++ b/frontend/src/locales/it/common.js
@@ -118,8 +118,7 @@ const TRANSLATIONS = {
     },
   },
   welcomeMessage: {
-    part1:
-      "Benvenuti in AnythingLLM, AnythingLLM è uno strumento di intelligenza artificiale open source di Mintplex Labs che trasforma qualsiasi cosa in un chatbot addestrato con cui puoi effettuare query e chattare. AnythingLLM è un software BYOK (bring-your-own-keys), quindi non ci sono abbonamenti, commissioni o costi per questo software al di fuori dei servizi che vuoi utilizzare.",
+    part1: "",
     part2:
       "AnythingLLM è il modo più semplice per mettere insieme potenti prodotti di intelligenza artificiale come OpenAi, GPT-4, LangChain, PineconeDB, ChromaDB e altri servizi in un pacchetto ordinato e senza problemi per aumentare la tua produttività di 100 volte.",
     part3:
@@ -135,7 +134,7 @@ const TRANSLATIONS = {
       "AnythingLLM è migliore di un Dropbox più smart.\n\nAnythingLLM offre due modi di comunicare con i tuoi dati:\n\n<i>Query:</i> Le tue chat restituiranno dati o inferenze trovate con i documenti nella tua area di lavoro a cui ha accesso. Aggiungere più documenti all'area di lavoro lo rende più intelligente! \n\n<i>Conversazionale:</i> i tuoi documenti + la cronologia delle chat in corso contribuiscono entrambi alla conoscenza dell'LLM allo stesso tempo. Ottimo per aggiungere informazioni basate su testo in tempo reale o correzioni e incomprensioni che l'LLM potrebbe avere. \n\nPuoi passare da una modalità all'altra \n<i>nel mezzo della chat!</i>",
     user3: "Wow, sembra fantastico, fammi provare!",
     part6: "Divertiti!",
-    starOnGitHub: "Metti una stella su GitHub",
+    starOnGitHub: "",
     contact: "Contatta Mintplex Labs",
   },
   "new-workspace": {

--- a/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
+++ b/frontend/src/pages/Admin/AgentBuilder/HeaderMenu/index.jsx
@@ -129,7 +129,7 @@ export default function HeaderMenu({
             </button>
           </div>
           <Link
-            to="https://docs.anythingllm.com/agent-flows/overview"
+            to="https://nytte.ai/agent-flows/overview"
             className="text-theme-text-secondary text-sm hover:underline hover:text-cta-button flex items-center gap-x-1 w-fit float-right"
           >
             view documentation &rarr;

--- a/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
+++ b/frontend/src/pages/Admin/Agents/AgentFlows/index.jsx
@@ -11,7 +11,7 @@ export default function AgentFlowsList({
       <div className="text-theme-text-secondary text-center text-xs flex flex-col gap-y-2">
         <p>No agent flows found</p>
         <a
-          href="https://docs.anythingllm.com/agent-flows/getting-started"
+          href="https://nytte.ai/agent-flows/getting-started"
           target="_blank"
           className="text-theme-text-secondary underline hover:text-cta-button"
         >

--- a/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
+++ b/frontend/src/pages/Admin/Agents/Imported/SkillList/index.jsx
@@ -13,7 +13,7 @@ export default function ImportedSkillList({
         <p>
           Learn about agent skills in the{" "}
           <a
-            href="https://docs.anythingllm.com/agent/custom/developer-guide"
+            href="https://nytte.ai/agent/custom/developer-guide"
             target="_blank"
             className="text-theme-text-secondary underline hover:text-cta-button"
           >

--- a/frontend/src/pages/Admin/Agents/MCPServers/index.jsx
+++ b/frontend/src/pages/Admin/Agents/MCPServers/index.jsx
@@ -53,7 +53,7 @@ export function MCPServerHeader({
         </div>
         <div className="flex items-center gap-x-3">
           <a
-            href="https://docs.anythingllm.com/mcp-compatibility/overview"
+            href="https://nytte.ai/mcp-compatibility/overview"
             target="_blank"
             rel="noopener noreferrer"
             className="border-none text-theme-text-secondary hover:text-cta-button"
@@ -108,7 +108,7 @@ export function MCPServersList({
       <div className="text-theme-text-secondary text-center text-xs flex flex-col gap-y-2">
         <p>No MCP servers found</p>
         <a
-          href="https://docs.anythingllm.com/mcp-compatibility/overview"
+            href="https://nytte.ai/mcp-compatibility/overview"
           target="_blank"
           rel="noopener noreferrer"
           className="text-theme-text-secondary underline hover:text-cta-button"

--- a/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/toggle.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/Features/LiveSync/toggle.jsx
@@ -66,7 +66,7 @@ export default function LiveSyncToggle({ enabled = false, onToggle }) {
         <ul className="space-y-2">
           <li>
             <a
-              href="https://docs.anythingllm.com/beta-preview/active-features/live-document-sync"
+              href="https://nytte.ai/beta-preview/active-features/live-document-sync"
               target="_blank"
               className="text-sm text-blue-400 light:text-blue-500 hover:underline flex items-center gap-x-1"
             >

--- a/frontend/src/pages/Admin/ExperimentalFeatures/index.jsx
+++ b/frontend/src/pages/Admin/ExperimentalFeatures/index.jsx
@@ -246,10 +246,10 @@ function FeatureVerification({ children }) {
                     Access to any features requires approval of this modal. If
                     you would like to read more you can refer to{" "}
                     <a
-                      href="https://docs.anythingllm.com/beta-preview/overview"
+                      href="https://nytte.ai/beta-preview/overview"
                       className="underline text-blue-500"
                     >
-                      docs.anythingllm.com
+                      nytte.ai
                     </a>{" "}
                     or email{" "}
                     <a

--- a/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentSkill.jsx
+++ b/frontend/src/pages/GeneralSettings/CommunityHub/ImportItem/Steps/PullAndReview/HubItem/AgentSkill.jsx
@@ -81,7 +81,7 @@ export default function AgentSkill({ item, settings, setStep }) {
             </p>
           )}
           <a
-            href="https://docs.anythingllm.com/community-hub/faq#verification"
+            href="https://nytte.ai/community-hub/faq#verification"
             target="_blank"
             className="text-xs font-mono text-blue-500 hover:underline"
             rel="noreferrer"

--- a/frontend/src/pages/GeneralSettings/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbedConfigs/EmbedRow/CodeSnippetModal/index.jsx
@@ -89,13 +89,7 @@ const ScriptTag = ({ embed }) => {
           Have your workspace chat embed function like a help desk chat bottom
           in the corner of your website.
         </p>
-        <a
-          href="https://github.com/Mintplex-Labs/anything-llm/tree/master/embed/README.md"
-          target="_blank"
-          className="text-blue-300 light:text-blue-500 hover:underline"
-        >
-          View all style and configuration options &rarr;
-        </a>
+        {/* Link removed for de-open-sourcing */}
       </div>
       <button
         disabled={copied}

--- a/frontend/src/pages/GeneralSettings/EmbedConfigs/NewEmbedModal/index.jsx
+++ b/frontend/src/pages/GeneralSettings/EmbedConfigs/NewEmbedModal/index.jsx
@@ -299,7 +299,7 @@ export const PermittedDomains = ({ defaultValue = [] }) => {
         value={domains}
         onChange={handleChange}
         onBlur={handleBlur}
-        placeholder="https://mysite.com, https://anythingllm.com"
+        placeholder="https://mysite.com, https://nytte.ai"
         classNames={{
           tag: "bg-theme-settings-input-bg light:bg-black/10 bg-blue-300/10 text-zinc-800",
           input:

--- a/frontend/src/utils/paths.js
+++ b/frontend/src/utils/paths.js
@@ -45,13 +45,13 @@ export default {
     },
   },
   github: () => {
-    return "https://github.com/Mintplex-Labs/anything-llm";
+    return null;
   },
   discord: () => {
-    return "https://discord.com/invite/6UyHPeGZAC";
+    return null; // Or simply remove this function if not used elsewhere
   },
   docs: () => {
-    return "https://docs.anythingllm.com";
+    return "https://nytte.ai";
   },
   mailToMintplex: () => {
     return "mailto:team@mintplexlabs.com";
@@ -196,7 +196,7 @@ export default {
       return `${this.website()}/me`;
     },
     noPrivateItems: () => {
-      return "https://docs.anythingllm.com/community-hub/faq#no-private-items";
+      return "https://nytte.ai/community-hub/faq#no-private-items";
     },
   },
 


### PR DESCRIPTION
This commit addresses several UI and localization requirements:

- Sets Danish (`da`) as the default fallback language.
- Removes user-visible links to Discord from the footer and utility paths.
- Replaces instances of `anythingllm.com` and `docs.anythingllm.com` with `nytte.ai` in user-facing links and text. This ensures that all documentation and external links point to the new domain.
- Removes mentions of "open source" and links to the project's GitHub repository from user-visible areas, including welcome messages, footers, and settings sections. This is to align with new branding requirements.

Changes were made across various frontend components, utility files, and localization files (including English, Danish, and Italian) to ensure consistency.


 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #xxx


### What is in this change?

<!-- Describe the changes in this PR that are impactful to the repo. -->


### Additional Information

<!-- Add any other context about the Pull Request here that was not captured above. -->

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
